### PR TITLE
chore: refresh pnpm-lock.yaml after ep_plugin_helpers dep add

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      ep_plugin_helpers:
+        specifier: ^0.5.0
+        version: 0.5.2
       regexp-quote:
         specifier: ^0.0.0
         version: 0.0.0
@@ -403,6 +406,10 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  ep_plugin_helpers@0.5.2:
+    resolution: {integrity: sha512-6M0gYqRTaF2SnTvV1OiqOZQ4B37ZHL0Zjoz3/eOIAXeCEBA4jId62uz9uboLs87Qcfae7eirDYWpdir5u5zkEQ==}
+    engines: {node: '>=18.0.0'}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -1679,6 +1686,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  ep_plugin_helpers@0.5.2: {}
 
   es-abstract@1.24.2:
     dependencies:


### PR DESCRIPTION
## Summary

Refreshes `pnpm-lock.yaml` to include `ep_plugin_helpers` (added to package.json by the earlier Phase-4 template-helper adoption commit). Without this, the release workflow's `pnpm install --frozen-lockfile` fails with `ERR_PNPM_OUTDATED_LOCKFILE` and the post-merge npm publish is blocked.

Generated with: `pnpm install --lockfile-only`.