### PR TITLE
fix: backward-compat for ESM etherpad

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const {template} = require('ep_plugin_helpers');
 
-const eejs = require('ep_etherpad-lite/node/eejs/');
+const eejs = require('ep_etherpad-lite/node/eejs');
 const padManager = require('ep_etherpad-lite/node/db/PadManager');
 
 exports.eejsBlock_indexWrapper =

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ep_list_pads",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "description": "List Pads on the Index Page",
   "author": {
     "name": "John McLear",


### PR DESCRIPTION
This PR makes the plugin backward-compatible with the upcoming ESM etherpad branch (ether/etherpad#7605).

**Change:** Remove trailing slash from `require("ep_etherpad-lite/node/eejs/")` → `require("ep_etherpad-lite/node/eejs")`

The trailing-slash form breaks under Node's strict ESM exports map resolution. This change is **backward-compatible** with the current CJS etherpad release.